### PR TITLE
Switched to constructor injection for properties

### DIFF
--- a/src/main/java/com/redhat/consulting/example/JMSRouteBuilder.java
+++ b/src/main/java/com/redhat/consulting/example/JMSRouteBuilder.java
@@ -2,6 +2,7 @@ package com.redhat.consulting.example;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.HashMap;
@@ -9,13 +10,21 @@ import java.util.HashMap;
 @ApplicationScoped
 public class JMSRouteBuilder extends RouteBuilder {
 
-	// Source endpoint URI injected using CDI in Quarkus (see: src/main/resources/application.properties)
-	@ConfigProperty(name = "jms.example.queue.inbound", defaultValue = "jms:queue:XML.QUEUE.1")
-	String jmsQueueInUri;
+	private static final Logger LOG = Logger.getLogger(JMSRouteBuilder.class);
 
-	// Destination endpoint URI injected using CDI in Quarkus (see: src/main/resources/application.properties)
-	@ConfigProperty(name = "jms.example.queue.outbound", defaultValue = "jms:queue:JSON.QUEUE.2")
-	String jmsQueueOutUri;
+	private String jmsQueueInUri;
+
+	private String jmsQueueOutUri;
+
+	public JMSRouteBuilder(
+			// Source endpoint URI injected using CDI in Quarkus (see: src/main/resources/application.properties)
+			@ConfigProperty(name = "jms.example.queue.inbound", defaultValue = "jms:queue:XML.QUEUE.1") String jmsQueueInUri,
+			// Destination endpoint URI injected using CDI in Quarkus (see: src/main/resources/application.properties)
+			@ConfigProperty(name = "jms.example.queue.outbound", defaultValue = "jms:queue:JSON.QUEUE.2") String jsmQueueOutUri
+	) {
+		this.jmsQueueInUri = jmsQueueInUri;
+		this.jmsQueueOutUri = jsmQueueOutUri;
+	}
 
 	@Override
 	public void configure() throws Exception {

--- a/src/test/java/com/redhat/consulting/example/JMSRouteBuilderTest.java
+++ b/src/test/java/com/redhat/consulting/example/JMSRouteBuilderTest.java
@@ -25,11 +25,11 @@ public class JMSRouteBuilderTest extends CamelTestSupport {
 
 	@Override
 	protected RouteBuilder createRouteBuilder() throws Exception {
-		JMSRouteBuilder jmsRouteBuilder = new JMSRouteBuilder();
+		JMSRouteBuilder jmsRouteBuilder = new JMSRouteBuilder("direct:start", "mock:dest");
 
 		// Set the in/out queue URIs for the RouteBuilder so that we can inject mocks and assert results
-		jmsRouteBuilder.jmsQueueInUri = "direct:start";
-		jmsRouteBuilder.jmsQueueOutUri = "mock:dest";
+//		jmsRouteBuilder.jmsQueueInUri = "direct:start";
+//		jmsRouteBuilder.jmsQueueOutUri = "mock:dest";
 
 		return jmsRouteBuilder;
 	}


### PR DESCRIPTION
Changed how `@ConfigProperty` values were being injected into the `JMSRouteBuilder` so that it's easier and clearer to see how properties are defined for both CDI and when doing unit tests.